### PR TITLE
Added RC4 128/128 to the RC4 cipher suite and RC4 128/128 unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the windows_schannel cookbook.
 
+## 0.1.4 - (19-09-2016)
+
+- Added RC4 128/128 to the RC4 cipher suite with RC4 128/128 unit test
+
 ## 0.1.3 - (20-06-2016)
 
 - Changed the description to make it easyer to understand what it does in the supermarket

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'digitalgaz@hotmail.com'
 license 'all_rights'
 description 'Configures windows schannel security support provider (SSP). Use it to disable support for the protocols like SSL and the RC4 Cipher. One step towards meeting CIS PCI FIPS compliance.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.3'
+version '0.1.4'
 supports 'windows'
 source_url 'https://github.com/digitalGaz/windows_schannel'
 issues_url 'https://github.com/digitalGaz/windows_schannel/issues' if respond_to?(:issues_url)

--- a/recipes/ciphers.rb
+++ b/recipes/ciphers.rb
@@ -65,7 +65,7 @@ when 'windows'
 
     case node['windows_schannel']['cipher_rc4']
     when 'disable'
-      ['RC4 40/128', 'RC4 56/128', 'RC4 64/128'].each do |cipher|
+      ['RC4 40/128', 'RC4 56/128', 'RC4 64/128', 'RC4 128/128'].each do |cipher|
         registry_key cipher do
           key "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Ciphers\\#{cipher}"
           recursive true
@@ -74,7 +74,7 @@ when 'windows'
         end
       end
     when 'enable'
-      ['RC4 40/128', 'RC4 56/128', 'RC4 64/128'].each do |cipher|
+      ['RC4 40/128', 'RC4 56/128', 'RC4 64/128', 'RC4 128/128'].each do |cipher|
         registry_key cipher do
           key "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Ciphers\\#{cipher}"
           recursive true

--- a/spec/unit/recipes/ciphers_spec.rb
+++ b/spec/unit/recipes/ciphers_spec.rb
@@ -23,6 +23,7 @@ describe 'windows_schannel::ciphers' do
     end
     it 'configures the cipher rc4' do
       expect(chef_run).to create_registry_key('RC4 40/128')
+      expect(chef_run).to create_registry_key('RC4 128/128')
     end
     it 'configures the cipher 3des' do
       expect(chef_run).to create_registry_key('cipher_3des')


### PR DESCRIPTION
RC4 128/128 is an additional RC4 cipher that is considered insecure. This pull request adds RC4 128/128 to the list of RC4 ciphers that are disabled when the RC4 attribute is set to 'disabled'. Microsoft security advisory (https://blogs.technet.microsoft.com/srd/2013/11/12/security-advisory-2868725-recommendation-to-disable-rc4/) includes RC4 128/128 as one of the ciphers to disable to completely disable RC4. 
