### PR TITLE
0.4.0 - Integration Tests now using InSpec

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  always_update_cookbooks: true
 
 verifier:
   name: inspec
@@ -17,4 +18,7 @@ suites:
   - name: default
     run_list:
       - recipe[windows_schannel::default]
+    verifier:
+      inspec_tests:
+        - test/smoke/default
     attributes:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ Metrics/LineLength:
 # Disabling due to it being a pita on windows
 Layout/EndOfLine:
   Enabled: false
+
+Lint/AmbiguousOperator:
+  Exclude:
+    - 'test/smoke/default/*_test.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the windows_schannel cookbook.
 
+# 0.4.0 - (06-10-2017)
+
+- Migrated the integration tests to inspec.
+- Changed some of the wording of the ChefSpec Tests
+
 ## 0.3.0 - (06-10-2017)
 
 - Corrected ChefSpec errors, warnings and now has 100% coverage
@@ -12,7 +17,7 @@ This file is used to list changes made in each version of the windows_schannel c
 
 ## 0.1.4 - (19-09-2016)
 
-- Added RC4 128/128 to the RC4 cipher suite with RC4 128/128 unit test
+- Added RC4 128/128 to the RC4 cipher suite with RC4 128/128 unit test (Thank You @brianbohanon)
 
 ## 0.1.3 - (20-06-2016)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'digitalgaz@hotmail.com'
 license 'Apache-2.0'
 description 'Configures windows schannel security support provider (SSP). Use it to disable support for the protocols like SSL and the RC4 Cipher. One step towards meeting CIS PCI FIPS compliance.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.4.0'
 
 source_url 'https://github.com/digitalGaz/windows_schannel' if respond_to?(:source_url)
 issues_url 'https://github.com/digitalGaz/windows_schannel/issues' if respond_to?(:issues_url)

--- a/spec/unit/recipes/ciphers_spec.rb
+++ b/spec/unit/recipes/ciphers_spec.rb
@@ -12,27 +12,27 @@ describe 'windows_schannel::ciphers' do
       runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '2012r2')
       runner.converge(described_recipe)
     end
-    it 'configures the cipher null' do
+    it 'configures the cipher NULL' do
       expect(chef_run).to create_registry_key('cipher_null')
     end
     it 'configures the cipher DES' do
       expect(chef_run).to create_registry_key('cipher_des')
     end
-    it 'configures the cipher rc2' do
+    it 'configures the cipher RC2' do
       expect(chef_run).to create_registry_key('RC2 40/128')
       expect(chef_run).to create_registry_key('RC2 56/128')
       expect(chef_run).to create_registry_key('RC2 128/128')
     end
-    it 'configures the cipher rc4' do
+    it 'configures the cipher RC4' do
       expect(chef_run).to create_registry_key('RC4 40/128')
       expect(chef_run).to create_registry_key('RC4 56/128')
       expect(chef_run).to create_registry_key('RC4 64/128')
       expect(chef_run).to create_registry_key('RC4 128/128')
     end
-    it 'configures the cipher 3des' do
+    it 'configures the cipher 3DES' do
       expect(chef_run).to create_registry_key('cipher_3des')
     end
-    it 'configures the cipher aes' do
+    it 'configures the cipher AES' do
       expect(chef_run).to create_registry_key('AES 128/128')
       expect(chef_run).to create_registry_key('AES 256/256')
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,6 +1,0 @@
-require 'spec_helper'
-
-describe 'windows_schannel::default' do
-  # TODO: Need to add my checks here. :)
-  # TODO: I'm still learning so happy to take a pull request if you could give me an example based on this cookbook
-end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,8 +1,0 @@
-require 'serverspec'
-
-if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
-  set :backend, :exec
-else
-  set :backend, :cmd
-  set :os, family: 'windows'
-end

--- a/test/smoke/default/ciphers_test.rb
+++ b/test/smoke/default/ciphers_test.rb
@@ -1,0 +1,60 @@
+control 'SCHANNEL : Ciphers : null ' do
+  title 'it should create a registry key and disable the cipher'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\NULL')
+  describe key do
+    its('Enabled') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Ciphers : DES' do
+  title 'it should create a registry key and disable the cipher'
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\DES 56/56') do
+    its('Enabled') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Ciphers : RC2' do
+  title 'it should create a registry key and disable the cipher'
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 40/128') do
+    its('Enabled') { should eq 0 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 56/128') do
+    its('Enabled') { should eq 0 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 128/128') do
+    its('Enabled') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Ciphers : RC4' do
+  title 'it should create a registry key and disable the cipher'
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128') do
+    its('Enabled') { should eq 0 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128') do
+    its('Enabled') { should eq 0 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 64/128') do
+    its('Enabled') { should eq 0 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128') do
+    its('Enabled') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Ciphers : 3DES' do
+  title 'it should create a registry key and disable the cipher'
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168/168') do
+    its('Enabled') { should eq -1 }
+  end
+end
+
+control 'SCHANNEL : Ciphers : AES' do
+  title 'it should create a registry key and disable the cipher'
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\AES 128/128') do
+    its('Enabled') { should eq -1 }
+  end
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\AES 256/256') do
+    its('Enabled') { should eq -1 }
+  end
+end

--- a/test/smoke/default/hashes_test.rb
+++ b/test/smoke/default/hashes_test.rb
@@ -1,0 +1,15 @@
+control 'SCHANNEL : Hashes : MD5 ' do
+  title 'it should create a registry key and enable the hash'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\MD5')
+  describe key do
+    its('Enabled') { should eq -1 }
+  end
+end
+
+control 'SCHANNEL : Hashes : SHA ' do
+  title 'it should create a registry key and enable the hash'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\SHA')
+  describe key do
+    its('Enabled') { should eq -1 }
+  end
+end

--- a/test/smoke/default/key_exchanges_test.rb
+++ b/test/smoke/default/key_exchanges_test.rb
@@ -1,0 +1,7 @@
+control 'SCHANNEL : KeyExchange : Diffie-Hellman' do
+  title 'it should create a registry key and enable the key exchange'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman')
+  describe key do
+    its('Enabled') { should eq -1 }
+  end
+end

--- a/test/smoke/default/protocols_test.rb
+++ b/test/smoke/default/protocols_test.rb
@@ -1,0 +1,56 @@
+control 'SCHANNEL : Protocols : PCT 1.0 ' do
+  title 'it should create a registry key and disable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\PCT 1.0\Server')
+  describe key do
+    its('Enabled') { should eq 0 }
+    its('DisabledByDefault') { should eq 1 }
+  end
+end
+
+control 'SCHANNEL : Protocols : SSL 2.0 ' do
+  title 'it should create a registry key and disable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Server')
+  describe key do
+    its('Enabled') { should eq 0 }
+    its('DisabledByDefault') { should eq 1 }
+  end
+end
+
+control 'SCHANNEL : Protocols : SSL 3.0 ' do
+  title 'it should create a registry key and disable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server')
+  describe key do
+    its('Enabled') { should eq 0 }
+    its('DisabledByDefault') { should eq 1 }
+  end
+end
+
+control 'SCHANNEL : Protocols : TLS 1.0 ' do
+  title 'it should create a registry key and enable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server')
+  describe key do
+    # -1 seem to match 0xffffffff ? will raise a issue to check
+    its('Enabled') { should eq -1 }
+    its('DisabledByDefault') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Protocols : TLS 1.1 ' do
+  title 'it should create a registry key and enable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server')
+  describe key do
+    # -1 seem to match 0xffffffff ? will raise a issue to check
+    its('Enabled') { should eq -1 }
+    its('DisabledByDefault') { should eq 0 }
+  end
+end
+
+control 'SCHANNEL : Protocols : TLS 1.2 ' do
+  title 'it should create a registry key and enable the protocol'
+  key = registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server')
+  describe key do
+    # -1 seem to match 0xffffffff ? will raise a issue to check
+    its('Enabled') { should eq -1 }
+    its('DisabledByDefault') { should eq 0 }
+  end
+end


### PR DESCRIPTION
There wasn't much in the way of intergration tests before.  These have now been writted using [InSpec](https://inspec.io) and you should have full coverage.  It might be nice to try and establish a connect to validate the protocol rather than just check the presence of the registry key, maybe something for the future.