### PR TITLE
0.4.1 - Fixed 3DES Cipher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the windows_schannel cookbook.
 
+# 0.4.1 - (06-10-2017)
+
+- The registry key for the 3DES Cipher was incorrect and as a result wasn't managing it correctly
+
 # 0.4.0 - (06-10-2017)
 
 - Migrated the integration tests to inspec.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'digitalgaz@hotmail.com'
 license 'Apache-2.0'
 description 'Configures windows schannel security support provider (SSP). Use it to disable support for the protocols like SSL and the RC4 Cipher. One step towards meeting CIS PCI FIPS compliance.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.0'
+version '0.4.1'
 
 source_url 'https://github.com/digitalGaz/windows_schannel' if respond_to?(:source_url)
 issues_url 'https://github.com/digitalGaz/windows_schannel/issues' if respond_to?(:issues_url)

--- a/recipes/ciphers.rb
+++ b/recipes/ciphers.rb
@@ -75,7 +75,7 @@ when 'windows'
     end
 
     registry_key 'cipher_3des' do
-      key 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168/168'
+      key 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168'
       recursive true
       case node['windows_schannel']['cipher_3des']
       when 'disable'

--- a/test/smoke/default/ciphers_test.rb
+++ b/test/smoke/default/ciphers_test.rb
@@ -44,7 +44,7 @@ end
 
 control 'SCHANNEL : Ciphers : 3DES' do
   title 'it should create a registry key and disable the cipher'
-  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168/168') do
+  describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168') do
     its('Enabled') { should eq -1 }
   end
 end


### PR DESCRIPTION
When externally testing a server I had requirement to disable the 3DES cipher.

There was typo in the registry key which meant that windows wasn't disabling it, this PR corrects that.

I've updated the intergration test to validate it as well.